### PR TITLE
most_summary & get_idx

### DIFF
--- a/get_idx.m
+++ b/get_idx.m
@@ -1,0 +1,91 @@
+function varargout = get_idx(om, varargin)
+%GET_IDX  Returns the idx struct for vars, lin/nonlin constraints, costs.
+%   VV = OM.GET_IDX()
+%   [VV, LL] = OM.GET_IDX()
+%   [VV, LL, NNE] = OM.GET_IDX()
+%   [VV, LL, NNE, NNI] = OM.GET_IDX()
+%   [VV, LL, NNE, NNI, CC] = OM.GET_IDX()
+%
+%   Returns a structure for each with the beginning and ending
+%   index value and the number of elements for each named block.
+%   The 'i1' field (that's a one) is a struct with all of the
+%   starting indices, 'iN' contains all the ending indices and
+%   'N' contains all the sizes. Each is a struct whose fields are
+%   the named blocks.
+%
+%   Alternatively, you can specify the type of named set(s) directly
+%   as inputs ...
+%
+%   [IDX1, IDX2, ...] = OM.GET_IDX(SET_TYPE1, SET_TYPE2, ...);
+%   [CC, VV] = OM.GET_IDX('cost', 'var');
+%   [LL, NNE, NNI] = OM.GET_IDX('lin', 'nle', 'nli');
+%
+%   The specific type of named set being referenced is
+%   given by the SET_TYPE inputs, with the following valid options:
+%       SET_TYPE = 'var'   => variable set
+%       SET_TYPE = 'lin'   => linear constraint set
+%       SET_TYPE = 'nle'   => nonlinear equality constraint set
+%       SET_TYPE = 'nli'   => nonlinear inequality constraint set
+%       SET_TYPE = 'cost'  => cost set
+%
+%   Examples:
+%       [vv, ll, nne] = om.get_idx();
+%       [vv, ll, cc] = om.get_idx('var', 'lin', 'cost');
+%
+%       For a variable block named 'z' we have ...
+%           vv.i1.z - starting index for 'z' in optimization vector x
+%           vv.iN.z - ending index for 'z' in optimization vector x
+%           vv.N.z  - number of elements in 'z'
+%
+%       To extract a 'z' variable from x:
+%           z = x(vv.i1.z:vv.iN.z);
+%
+%       To extract the multipliers on a linear constraint set
+%       named 'foo', where mu_l and mu_u are the full set of
+%       linear constraint multipliers:
+%           mu_l_foo = mu_l(ll.i1.foo:ll.iN.foo);
+%           mu_u_foo = mu_u(ll.i1.foo:ll.iN.foo);
+%
+%       The number of nonlinear equality constraints in a set named 'bar':
+%           nbar = nne.N.bar;
+%         (note: the following is preferable ...
+%           nbar = om.getN('nle', 'bar');
+%         ... if you haven't already called get_idx to get nne.)
+%
+%       If 'z', 'foo' and 'bar' are indexed sets, then you can
+%       replace them with something like 'z(i,j)', 'foo(i,j,k)'
+%       or 'bar(i)' in the examples above.
+%
+%   See also OPT_MODEL, ADD_VAR, ADD_LIN_CONSTRAINT, ADD_NLN_CONSTRAINT,
+%            ADD_QUAD_COST, ADD_NLN_COST and ADD_LEGACY_COST.
+
+%   MATPOWER
+%   Copyright (c) 2008-2017, Power Systems Engineering Research Center (PSERC)
+%   by Ray Zimmerman, PSERC Cornell
+%
+%   This file is part of MATPOWER.
+%   Covered by the 3-clause BSD License (see LICENSE file for details).
+%   See https://matpower.org for more info.
+
+if nargin == 1
+    varargout{1} = om.var.idx;
+    if nargout > 1
+        varargout{2} = om.lin.idx;
+        if nargout > 2
+            varargout{3} = om.nle.idx;
+            if nargout > 3
+                varargout{4} = om.nli.idx;
+                if nargout > 4
+                    varargout{5} = om.cost.idx;
+                    if nargout>5 %this if statement and the line below were added by baraa
+                        varargout{6} = om.qdc.idx;
+                    end
+                end
+            end
+        end
+    end
+else
+    for k = nargout:-1:1
+        varargout{k} = om.(varargin{k}).idx;
+    end
+end

--- a/most_summary.m
+++ b/most_summary.m
@@ -1,0 +1,271 @@
+function [mso,special_requests_repo] = most_summary(mdo,special_requests)
+%MOST_SUMMARY  Collects and optionally prints a summary of MOST results.
+%   MS = MOST_SUMMARY(MDO)
+%
+%   Note: Consider this function experimental. It is included because it
+%         is often better than nothing, though it is very incomplete.
+%
+%   Given a MOST data struct returned by MOST, returns a struct with the
+%   following fields:
+%       f       - objective function value
+%       nb      - number of buses
+%       ng      - number of generators (incl. storage, disp. load, etc.)
+%       nl      - number of branches
+%       nt      - number of periods in planning horizon
+%       nj_max  - max number of scenarios per period
+%       nc_max  - max number of contingencies per scenario in any period
+%       Pg      - ng x nt x nj_max x (nc_max+1), real power generation
+%       Rup     - ng x nt, upward ramping reserve quantities
+%       Rdn     - ng x nt, downward ramping reserve quantities
+%       Pf      - nl x nt x nj_max x (nc_max+1), real power generation
+%       u       - ng x nt x nj_max x (nc_max+1), generator commitment status
+%       lamP    - nb x nt x nj_max x (nc_max+1), shadow price on power balance
+%       muF     - nl x nt x nj_max x (nc_max+1), shadow price on flow limits
+%
+%   Printing to the console is currently controlled by the MDO.QP.verbose
+%   flag.
+
+%   MOST
+%   Copyright (c) 2015-2016, Power Systems Engineering Research Center (PSERC)
+%   by Ray Zimmerman, PSERC Cornell
+%
+%   This file is part of MOST.
+%   Covered by the 3-clause BSD License (see LICENSE file for details).
+%   See https://github.com/MATPOWER/most for more info.
+
+[PQ, PV, REF, NONE, BUS_I, BUS_TYPE, PD, QD, GS, BS, BUS_AREA, VM, ...
+    VA, BASE_KV, ZONE, VMAX, VMIN, LAM_P, LAM_Q, MU_VMAX, MU_VMIN] = idx_bus;
+[GEN_BUS, PG, QG, QMAX, QMIN, VG, MBASE, GEN_STATUS, PMAX, PMIN, ...
+    MU_PMAX, MU_PMIN, MU_QMAX, MU_QMIN, PC1, PC2, QC1MIN, QC1MAX, ...
+    QC2MIN, QC2MAX, RAMP_AGC, RAMP_10, RAMP_30, RAMP_Q, APF] = idx_gen;
+[F_BUS, T_BUS, BR_R, BR_X, BR_B, RATE_A, RATE_B, RATE_C, ...
+    TAP, SHIFT, BR_STATUS, PF, QF, PT, QT, MU_SF, MU_ST, ...
+    ANGMIN, ANGMAX, MU_ANGMIN, MU_ANGMAX] = idx_brch;
+
+tol = 1e-4;
+verbose = mdo.QP.opt.verbose;
+% verbose = 1;
+mpc = mdo.mpc;
+nb = size(mpc.bus, 1);
+nl = size(mpc.branch, 1);
+ng = size(mpc.gen, 1);
+nt = mdo.idx.nt;
+nj_max = max(mdo.idx.nj);
+nc_max = max(max(mdo.idx.nc));
+ns = mdo.idx.ns; %line added by baraa
+
+%% summarize results
+psi = zeros(nt, nj_max, nc_max+1);
+Pg = zeros(ng, nt, nj_max, nc_max+1);
+if mdo.idx.ntramp
+    Rup = [zeros(ng, 1) mdo.results.Rrp];
+    Rdn = [zeros(ng, 1) mdo.results.Rrm];
+else
+    Rup = [];
+    Rdn = [];
+end
+u = zeros(ng, nt);
+lamP = zeros(nb, nt, nj_max, nc_max+1);
+muF = zeros(nl, nt, nj_max, nc_max+1);
+Pf = zeros(nl, nt, nj_max, nc_max+1);
+for t = 1:nt
+  for j = 1:mdo.idx.nj(t)
+    for k = 1:mdo.idx.nc(t,j)+1
+      rr = mdo.flow(t,j,k).mpc;
+      psi(t, j, k) = mdo.CostWeightsAdj(k, j, t);
+      u(:, t) = rr.gen(:, GEN_STATUS);
+      Pg(:, t, j, k) = rr.gen(:, PG);
+      Pd(:, t, j, k) = rr.bus(:, PD); %This line was added by baraa
+      lamP(:, t, j, k) = rr.bus(:, LAM_P);
+      Pf(:, t, j, k) = rr.branch(:, PF);
+      muF(:, t, j, k) = rr.branch(:, MU_SF) + rr.branch(:, MU_ST);
+    end
+  end
+end
+
+ms = struct(...
+    'f',    mdo.QP.f + mdo.QP.c1, ...
+    'nb',   nb, ...
+    'ng',   ng, ...
+    'nl',   nl, ...
+    'nt',   nt, ...
+    'nj_max', nj_max, ...
+    'nc_max', nc_max, ...
+    'psi',  psi, ...
+    'Pg',   Pg, ...
+    'Pd',   Pd, ... %This line was added by baraa
+    'Rup',  Rup, ...
+    'Rdn',  Rdn, ...
+    'Pf',   Pf, ...
+    'u',    u, ...
+    'lamP', lamP, ...
+    'muF',  muF ...
+);    
+
+%==================== Special requests: brought to you by baraa==================== 
+if exist('special_requests') && ~isempty(special_requests)
+[vv,ll,nne,nni,cc,qdc] = mdo.om.get_idx();
+x = mdo.QP.x;
+[special_requests_repo,data_type] = deal(cell2struct(cell(numel(special_requests),1),special_requests));
+%I am doing this, this way, cuz some variables (like u, v, w) have one index only: (t)
+for i = 1:numel(special_requests)
+for tjk = 1:numel(vv.i1.(special_requests{i}))
+[t,j,k] = ind2sub(size(vv.i1.(special_requests{i})),tjk);
+idx = [vv.i1.(special_requests{i})(t,j,k):vv.iN.(special_requests{i})(t,j,k)]';
+special_requests_repo.(special_requests{i})(:,t,j,k) = x(idx);
+vt = mdo.om.var.data.vt.(special_requests{i})(t,j,k);
+
+%There are shorter (more comapct) ways to do this, but for sake of posterity....
+if contains(vt,'B') %if any one of these variables is binary, treat all as binary
+data_type.(special_requests{i}) = 'B';
+end
+end
+end
+else
+special_requests={};
+special_requests_repo=struct();
+end
+%==================== added by baraa==================== 
+
+%% print results
+if verbose
+    fprintf('\n========== OBJECTIVE  ==========\n');
+    fprintf('f = %.12g\n', ms.f);
+
+%     fprintf('\n========== GEN_STATUS ==========\n');
+%     fprintf(' Gen ');
+%     for t = 1:nt
+%         fprintf('   t =%2d ', t);
+%     end
+%     fprintf('\n');
+%     fprintf('----');
+%     for t = 1:nt
+%         fprintf('  -------');
+%     end
+%     fprintf('\n');
+% 
+%     for i = 1:ng
+%         fprintf('%4d', i);
+% %         fprintf('%9d', u(i, :));
+%         for t = 1:nt
+%             qty = u(i, t);
+%             if abs(qty) > tol
+%                 fprintf('      1  ');
+%             else
+%                 fprintf('    --0--');
+%             end
+%         end
+%         fprintf('\n');
+%     end
+%     fprintf('\n');
+    print_most_summary_section('GEN_STATUS', 'GEN', nt, 1, 0, u,'B'); %Line was added by baraa
+
+    if any(Pd(:))
+    print_most_summary_section('LOAD', 'Load', nt, nj_max, nc_max, Pd); %Line was added by baraa
+    else
+    disp('No fixed load exists. Check for dispatchable loads among GEN');
+    end
+    if mdo.idx.ns %If statement and print line was added by baraa
+    print_most_summary_section('ESS SoC', 'ESS', nt, 1, 0, mdo.Storage.ExpectedStorageState);
+%     print_most_summary_section('ESS SoC (%)', 'S', nt, 1, 0, 100*mdo.Storage.ExpectedStorageState./repmat(mdo.Storage.MaxStorageLevel,1,nt));
+    end
+    print_most_summary_section('PG', 'Gen', nt, nj_max, nc_max, Pg);
+
+    if mdo.idx.ntramp
+        print_most_summary_section('RAMP UP', 'Gen', nt, 1, 0, Rup);
+        print_most_summary_section('RAMP DOWN', 'Gen', nt, 1, 0, Rdn);
+    end
+
+    if mdo.DCMODEL %If statement was added by baraa; next 4 lines already existed; i just disabled them when if mdo.DCMODEL==0
+    print_most_summary_section('LAM_P', 'Bus', nt, nj_max, nc_max, lamP);
+    print_most_summary_section('P_From',   'Brch', nt, nj_max, nc_max, Pf); %changed by baraa from PF to P-from because PF confused me (power factor? no!)
+    print_most_summary_section('MU_F', 'Brch', nt, nj_max, nc_max, muF);
+    end
+
+    for i = 1:numel(special_requests)
+    data = special_requests_repo.(special_requests{i});
+    [~,nt_hat,nj_hat,nc_hat] = size(special_requests_repo.(special_requests{i}));
+    nc_hat = nc_hat - 1;
+    banner = ['SPECIAL REQUEST #',num2str(i),': "',upper(special_requests{i}),'"'];
+    vt = data_type.(special_requests{i});
+    print_most_summary_section(banner , upper(special_requests{i}), nt_hat, nj_hat, nc_hat, data,vt); %Line was added by baraa
+    end
+
+end
+
+if nargout
+    mso = ms;
+end
+
+%%---------------------------------------------------------
+function print_most_summary_section(label, section_type, nt, nj_max, nc_max, data, tol)
+if nargin < 7
+    tol = 1e-4;
+end
+
+if ischar(tol)
+tol = 1e-4;
+data_type = '%0.1d';
+else
+tol(isempty(tol))=1e-4;
+data_type = '%9.2f';
+end
+
+padding_size = 10;
+n = size(data, 1);
+fprintf('\n<strong>%s</strong>\n', pad([' ',deblank(label),' '],60,'both','='));
+for j = 1:nj_max
+    for k = 1:nc_max+1
+        if nj_max > 1 || nc_max > 0
+            fprintf('\nSCENARIO %d', j);
+            if nc_max == 0
+                fprintf('\n');
+            elseif k == 1
+                fprintf(', base case\n');
+            else
+                fprintf(', contingency %d\n', k-1);
+            end
+        end
+%         fprintf('%4s ', section_type);
+%         for t = 1:nt
+%             fprintf([repmat('%11d\t',1,nt),'\n'], [1:nt]);
+%         end
+%         fprintf('\n');
+%         fprintf('----');
+%         for t = 1:nt
+%             border_wall = repmat({'--------'},1,nt);
+%             fprintf([repmat('%12s',1,nt),'\n'],border_wall{:});
+%         end
+%         fprintf('\n');
+heading = [[section_type,'#'];strcat('t=',cellfun(@num2str,num2cell([1:nt]),'un',0))'];
+border = repmat({repmat('-',1,numel(num2str(nt))+6)},1,nt+1)';
+heading2 = pad([heading;border],padding_size,'both');
+disp(sprintf(['\n',repmat('<strong>%s</strong>',1,nt+1),'\n',repmat('%s',1,nt+1)],heading2{:}));
+%I use disp(sprinf(.... deliberately because it automatically inserts a line-break before and after a printed line
+qty = data(:,:,j,k);
+data_str0 = cellfun(@(x) num2str(x,'%d'),num2cell([1:size(data,1)]'),'un',0);
+data_cell = num2cell(qty);
+if strcmp(data_type,'%0.1d')
+data_cell(abs(qty)<tol) = {'-O-'};
+else
+data_cell(abs(qty)<tol) = {'-'};
+end
+data_str1 = cellfun(@(x) num2str(x,data_type),data_cell,'un',0);
+data_str2 = pad([data_str0, data_str1],padding_size,'both')';
+disp(sprintf(repmat([repmat('%s',1,nt+1),'\n'],1,size(data_str2,1)),data_str2{:}));
+
+%         for i = 1:n
+%             fprintf('%4d', i);
+%             for t = 1:nt
+%                 qty = data(i, t, j, k);
+%                 if abs(qty) > tol
+%                     fprintf('%9.2f', qty);
+%                 else
+%                     fprintf('      -  ');
+%                 end
+%             end
+%             fprintf('\n');
+%         end
+    end
+end
+fprintf('\n');


### PR DESCRIPTION
In MATPOWER-MOST cases with large nt (i.e. nt>100), the label "t = ...." starts drifting off away from the numbers below it.
1) I modified MOST_SUMMARY to utilize cell arrays, and the "pad" command to prevent this.
2) Made some lines print in bold
3) By default, this MOST_SUMMARY file also prints the load(t) and state-of-charge of energy-storage devices, at time (t), based on the value stored in Storage.ExpectedStorageState
3) Added the functionality/feature, to allow the user to request printing certain variables (which, otherwise, are not printed by default).
example for that is:
[res, repository] = most_summary(mdo, {'v', 'w', 'Psc'})

the variables 'v', 'w' and 'Psc' will be printed, which normally wouldn't happen.
Furthermore, the values for 'v', 'w' and 'Psc' would be extracted from mdo.QP.x, and returned in the structure "repository".
This feature only works on variables whose names are declared in mdo.om.var.idx.i1
variables inside MPC or UC or TSTEP, are not recognized.

4) The new MOST_SUMMARY file automatically checks whether a variable is binary or continuous. Binary variables are printed as 1 or -O-


The new MOST_SUMMARY file is a bit slower than the original version; but it still takes a few seconds to finish

================
for get_idx, the original file only returns variables (vv), linear constraints (ll), nonlinear constraints (nnli) and legacy costs (cc); but wouldn't return quadratic costs. I added that small bit as the last output-argument